### PR TITLE
Fix default command to work on other shells

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -30,7 +30,7 @@ bind ^A last-window
 set -g base-index 1
 
 # Change default command to work in OSX
-set -g default-command "which reattach-to-user-namespace > /dev/null && reattach-to-user-namespace -l $SHELL || $SHELL -l"
+set -g default-command "bash -c 'which reattach-to-user-namespace > /dev/null && reattach-to-user-namespace -l $SHELL || $SHELL -l'"
 
 # Activity monitoring: highlight window with new messages
 setw -g monitor-activity on


### PR DESCRIPTION
The default command does not work on other shells like fish.
This pull-request uses bash -c to execute, so it is portable
enought.